### PR TITLE
Fix issue of X-CSRF-TOKEN

### DIFF
--- a/BKSchedule_Rewrite.py
+++ b/BKSchedule_Rewrite.py
@@ -4,7 +4,6 @@ import json
 import getpass
 import sys
 from datetime import datetime, date, time, timedelta
-import random
 
 # External libraries
 import requests

--- a/BKSchedule_Rewrite.py
+++ b/BKSchedule_Rewrite.py
@@ -58,7 +58,7 @@ if not os.path.exists('credential.json'):
 
             assert second_pw == second_pw_2
             # Destroy password confirmation variable to prevent leakage
-            second_pw_2 = os.urandom(1)
+            del second_pw_2
             break # Break out
         except AssertionError:
             print('Mật khẩu cấp hai được nhập không khớp nhau. Vui lòng thực hiện lại\n')
@@ -69,7 +69,7 @@ if not os.path.exists('credential.json'):
                                                password=second_pw)
     print('Mã hóa thành công thông tin MyBK của bạn')
     # Destroy second password and plain text data in memory for security
-    second_pw, user_credential= [os.urandom(1) for i in range(2)]
+    del second_pw, user_credential
 
     # Store the encrypted data
     with open('credential.json', 'w') as f:
@@ -94,7 +94,7 @@ else:
                                                    salt=salt,
                                                    tag=tag)
             # Destroy the correct key
-            second_pw = os.urandom(1)
+            del second_pw
             print('Giải mã thành công.')
             break
         except ValueError:
@@ -102,7 +102,7 @@ else:
 
     # Load decrypted data into variables and destroy the decrypted
     username, password = [json.loads(user_credential)[i] for i in ['username', 'password']]
-    user_credential = os.urandom(1)
+    del user_credential, nonce, salt, tag
 
 # Preliminary sanity check
 if any([i == '' for i in (username, password)]):

--- a/BKSchedule_Rewrite.py
+++ b/BKSchedule_Rewrite.py
@@ -153,23 +153,19 @@ try:
     r = BS(r.content, 'html5lib')
     
     # Preparation before grabbing the timetable
-    csrf_token = r.find('meta', {'name': '_token'}).attrs['content']
-    s.headers.update({'X-CSRF-TOKEN': csrf_token, 
+    token = r.find('meta', {'name': '_token'}).attrs['content']
+    s.headers.update({'X-CSRF-TOKEN': token, 
                       'X-Requested-With': 'XMLHttpRequest'})
     
-    # Grabbing the token to get the timetable
+    # Grabbing the token to get the timetable. CSRF Token here doubles as timetable token
     print('Tải thời khóa biểu về...')
-    r = s.get('https://mybk.hcmut.edu.vn/stinfo/lichhoc')
-    r = BS(r.content, 'html5lib')
-    
-    timetable_token = r.find('meta', {'name': '_token'}).attrs['content']
-    r = s.post('https://mybk.hcmut.edu.vn/stinfo/lichthi/ajax_lichhoc', json={'_token': timetable_token})
+    r = s.post('https://mybk.hcmut.edu.vn/stinfo/lichthi/ajax_lichhoc', json={'_token': token})
     
     # Convert the jargon into a proper JSON dict
     timetable = r.json()
     
     # Destroy the session altogether
-    del sso_token, csrf_token, timetable_token, r, s
+    del sso_token, token, r, s
 
     # Cache the data just in case
     with open(cached_file, 'w') as f:


### PR DESCRIPTION
Resolves #1. Issues surfaced after an incomplete code transfer from v1 up to v2. X-CSRF-TOKEN being wrong doesn't affect the program since `v2.0.1` was running normally, but this can be used to isolate the program and block it to enforce using a web browser which is against what this program is all for.

Fix wouldn't have been possible without insights from https://github.com/Circu1tI0N3rd/BKSCrawler